### PR TITLE
eapi: bump to 7 version

### DIFF
--- a/dev-libs/msgpuck/msgpuck-9999.ebuild
+++ b/dev-libs/msgpuck/msgpuck-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="Lightweight MessagePack library"
 HOMEPAGE="https://github.com/tarantool/msgpuck"

--- a/dev-libs/tarantool-c/tarantool-c-9999.ebuild
+++ b/dev-libs/tarantool-c/tarantool-c-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION=""
 HOMEPAGE="https://github.com/tarantool/tarantool-c"
@@ -39,5 +39,5 @@ src_configure() {
 	local mycmakeargs=(
 		-DENABLE_BUNDLED_MSGPUCK=$(usex system-msgpuck OFF ON)
 	)
-	cmake-utils_src_configure
+	cmake_src_configure
 }

--- a/dev-lua/argon2/argon2-9999.ebuild
+++ b/dev-lua/argon2/argon2-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 CMAKE_MAKEFILE_GENERATOR="emake"
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="Tarantool C binding for the Argon2 password hashing algorithm"
 HOMEPAGE="https://github.com/tarantool/argon2/"

--- a/dev-lua/avro-schema/avro-schema-9999.ebuild
+++ b/dev-lua/avro-schema/avro-schema-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="Apache Avro schema tools for Tarantool"
 HOMEPAGE="https://github.com/tarantool/avro-schema/"

--- a/dev-lua/checks/checks-9999.ebuild
+++ b/dev-lua/checks/checks-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 DESCRIPTION="Easy, terse, readable and fast function arguments type checking"
 HOMEPAGE="https://github.com/tarantool/checks"

--- a/dev-lua/connpool/connpool-9999.ebuild
+++ b/dev-lua/connpool/connpool-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 DESCRIPTION="Lua connection pool for tarantool net.box"
 HOMEPAGE="https://github.com/tarantool/connpool"

--- a/dev-lua/expirationd/expirationd-9999.ebuild
+++ b/dev-lua/expirationd/expirationd-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 DESCRIPTION="Expiration daemon module for Tarantool"
 HOMEPAGE="https://github.com/tarantool/expirationd"

--- a/dev-lua/http/http-9999.ebuild
+++ b/dev-lua/http/http-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="HTTP server for Tarantool"
 HOMEPAGE="https://github.com/tarantool/http/"

--- a/dev-lua/luatest/luatest-9999.ebuild
+++ b/dev-lua/luatest/luatest-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="Tarantool test framework written in Lua"
 HOMEPAGE="https://github.com/tarantool/luatest/"

--- a/dev-lua/mysql/mysql-9999.ebuild
+++ b/dev-lua/mysql/mysql-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="MySQL connector for Tarantool"
 HOMEPAGE="https://github.com/tarantool/mysql/"

--- a/dev-lua/pg/pg-9999.ebuild
+++ b/dev-lua/pg/pg-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="PostgreSQL connector for Tarantool"
 HOMEPAGE="https://github.com/tarantool/pg"

--- a/dev-lua/queue/queue-9999.ebuild
+++ b/dev-lua/queue/queue-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="Create task queues, add and take jobs, monitor failed tasks"
 HOMEPAGE="https://github.com/tarantool/queue/"

--- a/dev-lua/shard/shard-9999.ebuild
+++ b/dev-lua/shard/shard-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="Automatic sharding and resharding"
 HOMEPAGE="https://github.com/tarantool/shard/"

--- a/dev-lua/smtp/smtp-9999.ebuild
+++ b/dev-lua/smtp/smtp-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="SMTP support for Tarantool"
 HOMEPAGE="https://github.com/tarantool/smtp/"


### PR DESCRIPTION
Some ebuilds uses the cmake-utils and versionator eclasses.
These eclasses have been removed.

Closes #50