### PR TITLE
dev-db/tarantool: fix build with system-zstd

### DIFF
--- a/dev-db/tarantool/tarantool-9999.ebuild
+++ b/dev-db/tarantool/tarantool-9999.ebuild
@@ -164,6 +164,12 @@ src_configure() {
 		export CMAKE_BUILD_TYPE=RelWithDebInfo
 	fi
 
+	# https://github.com/tarantool/gentoo-overlay/issues/73
+	if use system-zstd; then
+		CFLAGS="$CFLAGS -Wno-deprecated-declarations"
+		CXXFLAGS="$CXXFLAGS -Wno-deprecated-declarations"
+	fi
+
 	local mycmakeargs=(
 		-DENABLE_BACKTRACE="$(usex backtrace)"
 		-DENABLE_SSE2="$(usex cpu_flags_x86_sse2)"


### PR DESCRIPTION
Current zstd version deprecates some API used in tarantool. https://github.com/tarantool/tarantool/issues/8537

Closes #73