### PR TITLE
dev-db/tarantool: cmake was moved

### DIFF
--- a/dev-db/tarantool/tarantool-9999.ebuild
+++ b/dev-db/tarantool/tarantool-9999.ebuild
@@ -51,7 +51,7 @@ LICENSE="BSD-2"
 BDEPEND="
 	acct-group/tarantool
 	acct-user/tarantool
-	>=dev-util/cmake-2.6
+	>=dev-build/cmake-2.6
 "
 
 RDEPEND="


### PR DESCRIPTION
See https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-build/cmake?id=2f9c42cb12b476a78214e2f7d5bb3f984ce05de6